### PR TITLE
Cargar como argumento el input que contiene el RUT

### DIFF
--- a/js/jquery.rut.chileno.js
+++ b/js/jquery.rut.chileno.js
@@ -31,7 +31,7 @@ Versión: 1.7
 			$t.on(defaults.on, function(){
 				$('.rut-error').remove();
 				if($.rut.validar($t.val()) && $.trim($t.val()) != '')
-				defaults.fn_validado();
+				defaults.fn_validado($t);
 				else
 				defaults.fn_error($t);
 			});


### PR DESCRIPTION
Basado en la personalización de @kadumedia donde señala la **opción fn_error(input)**, **fn_validado(input)** 

Se trabaja con el ejemplo señalado en el readme

```
$('.input_rut').rut({
      fn_error : function(input){
        alert('El rut: ' + input.val() + ' es incorrecto');
      },
      placeholder: false
    });
```

Se añade al ejemplo la función **fn_validado(input)**

```
$('.input_rut').rut({
      fn_error : function(input){
        alert('El rut: ' + input.val() + ' es incorrecto');
      },
      fn_validado : function(input){
        alert('El rut: ' + input.val() + ' es correcto');
      },
      placeholder: false
    });
```

El navegador informa el siguiente error:
_fn_validado error, input no está definido_

PARCHE: Integrar como argumento el input, que se señala en las opciones, pero nunca carga su valor